### PR TITLE
Fixed Undo Option

### DIFF
--- a/RahulAnand442001/drawably/canvas.js
+++ b/RahulAnand442001/drawably/canvas.js
@@ -42,7 +42,8 @@ window.addEventListener("load", () => {
   undoButton.onclick = handleUndo;
   function handleUndo() {
     if (index <= 0) {
-      clear_canvas();
+      handleClearCanvas();
+      return null;
     }
     index -= 1;
     drawHistory.pop();


### PR DESCRIPTION
Program had a minor bug in which undo option was not working for the last element. i.e. If only one element was remaining undo button was not working.

# The error
-> On line no. 45 of drawbly/canvas.js
-> No clear_canvas() method existed, there was a typo.

# The Fix
-> Changed the method name to correct method name handleClearCanvas() -> Added a return statement thereafter